### PR TITLE
Makes it noticeable and actionable when a required markdown field is empty.

### DIFF
--- a/themes/default/static/css/less/components/modal.less
+++ b/themes/default/static/css/less/components/modal.less
@@ -26,6 +26,14 @@
     font-size: 20px;
     margin: 30px 0 20px;
     padding-bottom: 5px;
-    text-transform: capitalize;    
+    text-transform: capitalize;
+  }
+}
+
+modalmarkdowneditor {
+  .markdown-required .editable {
+    min-height: 4.5em;
+    background-color: lighten(@brand-danger, 40%);
+    border-radius: 0.75em;
   }
 }


### PR DESCRIPTION
Fixes #510.
